### PR TITLE
Add new helpers

### DIFF
--- a/core_extensions/active_record/migration/command_recorder.rb
+++ b/core_extensions/active_record/migration/command_recorder.rb
@@ -1,0 +1,18 @@
+module CoreExtensions
+  module ActiveRecord
+    module Migration
+      module CommandRecorder
+        def create_table_with_distributed(*args, &block)
+          record(:create_table_with_distributed, args, &block)
+        end
+
+        private
+
+        def invert_create_table_with_distributed(args)
+          table_name, options = args
+          [:drop_table_with_distributed, table_name, options]
+        end
+      end
+    end
+  end
+end

--- a/core_extensions/active_record/migration/command_recorder.rb
+++ b/core_extensions/active_record/migration/command_recorder.rb
@@ -6,11 +6,20 @@ module CoreExtensions
           record(:create_table_with_distributed, args, &block)
         end
 
+        def create_view(*args, &block)
+          record(:create_view, args, &block)
+        end
+
         private
 
         def invert_create_table_with_distributed(args)
           table_name, options = args
           [:drop_table_with_distributed, table_name, options]
+        end
+
+        def invert_create_view(args)
+          view_name, options = args
+          [:drop_table, view_name, options]
         end
       end
     end

--- a/lib/active_record/connection_adapters/clickhouse/schema_creation.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_creation.rb
@@ -46,17 +46,48 @@ module ActiveRecord
           create_sql
         end
 
+        def add_as_clause!(create_sql, options)
+          return unless options.as
+
+          assign_database_to_subquery!(options.as) if options.view
+          create_sql << " AS #{to_sql(options.as)}"
+        end
+
+        def assign_database_to_subquery!(subquery)
+          # If you do not specify a database explicitly, ClickHouse will use the "default" database.
+          return unless subquery
+
+          match = subquery.match(/(?<=from)[^.\w]+(?<database>\w+(?=\.))?(?<table_name>[.\w]+)/i)
+          return unless match
+          return if match[:database]
+
+          subquery[match.begin(:table_name)...match.end(:table_name)] =
+            "#{current_database}.#{match[:table_name].sub('.', '')}"
+        end
+
+        def add_to_clause!(create_sql, options)
+          # If you do not specify a database explicitly, ClickHouse will use the "default" database.
+          return unless options.to
+
+          match = options.to.match(/(?<database>.+(?=\.))?(?<table_name>.+)/i)
+          return unless match
+          return if match[:database]
+
+          create_sql << "TO #{current_database}.#{options.to.sub('.', '')} "
+        end
+
         def visit_TableDefinition(o)
           create_sql = +"CREATE#{table_modifier_in_create(o)} #{o.view ? "VIEW" : "TABLE"} "
           create_sql << "IF NOT EXISTS " if o.if_not_exists
           create_sql << "#{quote_table_name(o.name)} "
+          add_to_clause!(create_sql, o) if o.materialized
 
           statements = o.columns.map { |c| accept c }
           statements << accept(o.primary_keys) if o.primary_keys
           create_sql << "(#{statements.join(', ')})" if statements.present?
-          # Attach options for only table or materialized view
-          add_table_options!(create_sql, o)  if !o.view || o.view && o.materialized
-          create_sql << " AS #{to_sql(o.as)}" if o.as
+          # Attach options for only table or materialized view without TO section
+          add_table_options!(create_sql, o) if !o.view || o.view && o.materialized && !o.to
+          add_as_clause!(create_sql, o)
           create_sql
         end
 
@@ -84,6 +115,9 @@ module ActiveRecord
           change_column_sql
         end
 
+        def current_database
+          ActiveRecord::Base.connection_db_config.database
+        end
       end
     end
   end

--- a/lib/active_record/connection_adapters/clickhouse/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_definitions.rb
@@ -5,7 +5,7 @@ module ActiveRecord
     module Clickhouse
       class TableDefinition < ActiveRecord::ConnectionAdapters::TableDefinition
 
-        attr_reader :view, :materialized, :if_not_exists
+        attr_reader :view, :materialized, :if_not_exists, :to
 
         def initialize(
             conn,
@@ -17,6 +17,7 @@ module ActiveRecord
             comment: nil,
             view: false,
             materialized: false,
+            to: nil,
             **
           )
           @conn = conn
@@ -32,6 +33,7 @@ module ActiveRecord
           @comment = comment
           @view = view || materialized
           @materialized = materialized
+          @to = to
         end
 
         def integer(*args, **options)
@@ -58,7 +60,7 @@ module ActiveRecord
               kind = :int256     if options[:limit] > 16
             end
           end
-          args.each { |name| column(name, kind, options.except(:limit, :unsigned)) }
+          args.each { |name| column(name, kind, **options.except(:limit, :unsigned)) }
         end
       end
     end

--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -262,7 +262,7 @@ module ActiveRecord
       def create_view(table_name, **options)
         options.merge!(view: true)
         options = apply_replica(table_name, options)
-        td = create_table_definition(apply_cluster(table_name), options)
+        td = create_table_definition(apply_cluster(table_name), **options)
         yield td if block_given?
 
         if options[:force]
@@ -272,16 +272,29 @@ module ActiveRecord
         execute schema_creation.accept td
       end
 
-      def create_table(table_name, **options)
+      def create_table(table_name, **options, &block)
         options = apply_replica(table_name, options)
-        td = create_table_definition(apply_cluster(table_name), options)
-        yield td if block_given?
+        td = create_table_definition(apply_cluster(table_name), **options)
+        block.call td if block_given?
 
         if options[:force]
           drop_table(table_name, options.merge(if_exists: true))
         end
 
         execute schema_creation.accept td
+      end
+
+      def create_table_with_distributed(table_name, **options, &block)
+        sharding_key = options.delete(:sharding_key) || 'rand()'
+        create_table("#{table_name}_distributed", **options, &block)
+        raise 'Set a cluster' unless cluster
+
+        distributed_options = "Distributed(#{cluster},#{@config[:database]},#{table_name}_distributed,#{sharding_key})"
+        create_table(table_name, **options.merge(options: distributed_options), &block)
+      end
+
+      def drop_table_with_distributed(table_name, **options)
+        ["#{table_name}_distributed", table_name].each { |name| drop_table(name, **options) }
       end
 
       # Drops a ClickHouse database.

--- a/lib/clickhouse-activerecord.rb
+++ b/lib/clickhouse-activerecord.rb
@@ -2,6 +2,9 @@
 
 require 'active_record/connection_adapters/clickhouse_adapter'
 
+require_relative '../core_extensions/active_record/migration/command_recorder'
+ActiveRecord::Migration::CommandRecorder.include CoreExtensions::ActiveRecord::Migration::CommandRecorder
+
 if defined?(Rails::Railtie)
   require 'clickhouse-activerecord/railtie'
   require 'clickhouse-activerecord/schema'

--- a/lib/clickhouse-activerecord/migration.rb
+++ b/lib/clickhouse-activerecord/migration.rb
@@ -67,6 +67,16 @@ module ClickhouseActiverecord
       @schema_migration = schema_migration
     end
 
+    def up(target_version = nil)
+      selected_migrations = if block_given?
+        migrations.select { |m| yield m }
+      else
+        migrations
+      end
+
+      ClickhouseActiverecord::Migrator.new(:up, selected_migrations, schema_migration, target_version).migrate
+    end
+
     def down(target_version = nil)
       selected_migrations = if block_given?
         migrations.select { |m| yield m }

--- a/spec/cases/migration_spec.rb
+++ b/spec/cases/migration_spec.rb
@@ -71,6 +71,7 @@ RSpec.describe 'Migration', :migrations do
             end
           end
         end
+
         context 'with distributed' do
           let(:model_distributed) do
             Class.new(ActiveRecord::Base) do
@@ -117,6 +118,30 @@ RSpec.describe 'Migration', :migrations do
 
             expect(ActiveRecord::Base.connection.tables).not_to include('some')
             expect(ActiveRecord::Base.connection.tables).not_to include('some_distributed')
+          end
+        end
+
+        context 'view' do
+          it 'creates a view' do
+            migrations_dir = File.join(FIXTURES_PATH, 'migrations', 'dsl_create_view_with_to_section')
+            quietly { ActiveRecord::MigrationContext.new(migrations_dir, ClickhouseActiverecord::SchemaMigration).up }
+
+            expect(ActiveRecord::Base.connection.tables).to include('some_view')
+          end
+
+          it 'drops a view' do
+            migrations_dir = File.join(FIXTURES_PATH, 'migrations', 'dsl_create_view_without_to_section')
+            quietly { ActiveRecord::MigrationContext.new(migrations_dir, ClickhouseActiverecord::SchemaMigration).up }
+
+            expect(ActiveRecord::Base.connection.tables).to include('some_view')
+            expect(ActiveRecord::Base.connection.tables).to include('.inner.some_view')
+
+            quietly do
+              ClickhouseActiverecord::MigrationContext.new(migrations_dir, ClickhouseActiverecord::SchemaMigration).down
+            end
+
+            expect(ActiveRecord::Base.connection.tables).not_to include('some_view')
+            expect(ActiveRecord::Base.connection.tables).not_to include('.inner.some_view')
           end
         end
       end

--- a/spec/cases/migration_spec.rb
+++ b/spec/cases/migration_spec.rb
@@ -71,6 +71,54 @@ RSpec.describe 'Migration', :migrations do
             end
           end
         end
+        context 'with distributed' do
+          let(:model_distributed) do
+            Class.new(ActiveRecord::Base) do
+              self.table_name = 'some_distributed'
+            end
+          end
+          connection_config = ActiveRecord::Base.connection_db_config.configuration_hash
+
+          before(:all) do
+            ActiveRecord::Base.establish_connection(connection_config.merge(cluster_name: CLUSTER_NAME))
+          end
+
+          after(:all) do
+            ActiveRecord::Base.establish_connection(connection_config)
+          end
+
+          it 'creates a table with distributed table' do
+            migrations_dir = File.join(FIXTURES_PATH, 'migrations', 'dsl_create_table_with_distributed')
+            quietly { ActiveRecord::MigrationContext.new(migrations_dir, ClickhouseActiverecord::SchemaMigration).up }
+
+            current_schema = schema(model)
+            current_schema_distributed = schema(model_distributed)
+
+            expect(current_schema.keys.count).to eq(1)
+            expect(current_schema_distributed.keys.count).to eq(1)
+
+            expect(current_schema).to have_key('date')
+            expect(current_schema_distributed).to have_key('date')
+
+            expect(current_schema['date'].sql_type).to eq('Date')
+            expect(current_schema_distributed['date'].sql_type).to eq('Date')
+          end
+
+          it 'drops a table with distributed table' do
+            migrations_dir = File.join(FIXTURES_PATH, 'migrations', 'dsl_create_table_with_distributed')
+            quietly { ActiveRecord::MigrationContext.new(migrations_dir, ClickhouseActiverecord::SchemaMigration).up }
+
+            expect(ActiveRecord::Base.connection.tables).to include('some')
+            expect(ActiveRecord::Base.connection.tables).to include('some_distributed')
+
+            quietly do
+              ClickhouseActiverecord::MigrationContext.new(migrations_dir, ClickhouseActiverecord::SchemaMigration).down
+            end
+
+            expect(ActiveRecord::Base.connection.tables).not_to include('some')
+            expect(ActiveRecord::Base.connection.tables).not_to include('some_distributed')
+          end
+        end
       end
     end
 

--- a/spec/fixtures/migrations/dsl_create_table_with_distributed/1_create_some_table.rb
+++ b/spec/fixtures/migrations/dsl_create_table_with_distributed/1_create_some_table.rb
@@ -1,0 +1,7 @@
+class CreateSomeTable < ActiveRecord::Migration[5.0]
+  def change
+    create_table_with_distributed :some, options: 'MergeTree(date, (date), 8192)' do |t|
+      t.date :date, null: false
+    end
+  end
+end

--- a/spec/fixtures/migrations/dsl_create_view_with_to_section/1_create_some_table_1.rb
+++ b/spec/fixtures/migrations/dsl_create_view_with_to_section/1_create_some_table_1.rb
@@ -1,0 +1,7 @@
+class CreateSomeTable1 < ActiveRecord::Migration[5.0]
+  def change
+    create_table :some_table_1, options: 'MergeTree() ORDER BY col' do |t|
+      t.string :col, null: false
+    end
+  end
+end

--- a/spec/fixtures/migrations/dsl_create_view_with_to_section/2_create_some_table_2.rb
+++ b/spec/fixtures/migrations/dsl_create_view_with_to_section/2_create_some_table_2.rb
@@ -1,0 +1,7 @@
+class CreateSomeTable2 < ActiveRecord::Migration[5.0]
+  def change
+    create_table :some_table_2, options: 'MergeTree() ORDER BY col' do |t|
+      t.string :col, null: false
+    end
+  end
+end

--- a/spec/fixtures/migrations/dsl_create_view_with_to_section/3_create_some_view.rb
+++ b/spec/fixtures/migrations/dsl_create_view_with_to_section/3_create_some_view.rb
@@ -1,0 +1,6 @@
+class CreateSomeView < ActiveRecord::Migration[5.0]
+  def change
+    create_view :some_view, materialized: true, as: 'select * from some_table_1', to: 'some_table_2'
+  end
+end
+

--- a/spec/fixtures/migrations/dsl_create_view_without_to_section/1_create_some_table.rb
+++ b/spec/fixtures/migrations/dsl_create_view_without_to_section/1_create_some_table.rb
@@ -1,0 +1,7 @@
+class CreateSomeTable < ActiveRecord::Migration[5.0]
+  def change
+    create_table :some_table, options: 'MergeTree() ORDER BY col' do |t|
+      t.string :col, null: false
+    end
+  end
+end

--- a/spec/fixtures/migrations/dsl_create_view_without_to_section/2_create_some_view.rb
+++ b/spec/fixtures/migrations/dsl_create_view_without_to_section/2_create_some_view.rb
@@ -1,0 +1,5 @@
+class CreateSomeView < ActiveRecord::Migration[5.0]
+  def change
+    create_view :some_view, materialized: true, as: 'select * from some_table'
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ require 'clickhouse-activerecord'
 require 'active_support/testing/stream'
 
 FIXTURES_PATH = File.join(File.dirname(__FILE__), 'fixtures')
+CLUSTER_NAME = 'test'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
@@ -21,9 +22,13 @@ RSpec.configure do |config|
   end
 
   config.around(:each, :migrations) do |example|
-    ActiveRecord::Base.connection.tables.each { |table| ActiveRecord::Base.connection.execute("DROP TABLE #{table}") }
+    clear_consts
+    clear_db
+
     example.run
-    ActiveRecord::Base.connection.tables.each { |table| ActiveRecord::Base.connection.execute("DROP TABLE #{table}") }
+
+    clear_consts
+    clear_db
   end
 end
 
@@ -44,5 +49,28 @@ def schema(model)
   model.reset_column_information
   model.columns.each_with_object({}) do |c, h|
     h[c.name] = c
+  end
+end
+
+def clear_db
+  current_cluster_name = ActiveRecord::Base.connection_db_config.configuration_hash[:cluster_name]
+  pattern = if current_cluster_name
+              "DROP TABLE %s ON CLUSTER #{current_cluster_name}"
+            else
+              'DROP TABLE %s'
+            end
+
+  ActiveRecord::Base.connection.tables.each { |table| ActiveRecord::Base.connection.execute(pattern % table) }
+end
+
+def clear_consts
+  $LOADED_FEATURES.select { |file| file.include? FIXTURES_PATH }.each do |file|
+    const = File.basename(file)
+                .scan(ActiveRecord::Migration::MigrationFilenameRegexp)[0][1]
+                .camelcase
+                .safe_constantize
+
+    Object.send(:remove_const, const.to_s) if const
+    $LOADED_FEATURES.delete(file)
   end
 end


### PR DESCRIPTION
Description of commits:

1. **create_table_with_distributed helper**. I've added helper that creates two tables at once (with distributed engine and *MergeTree).

2. **auto-create service tables with distributed tables**. When I use multiple shards, I would like to create distributed tables for the service tables by default (during the first migration).

3. **fixed "up" migration**. Initially, during the first migration, the service tables (schema_migrations and ar_internal_metadata) were created using the MigrationContext provided by ActiveRecord, which did not call ClickhouseActiverecord::Migrator. This was the reason why gem did not execute the sql described in ClickhouseActiverecord::SchemaMigration during the first migration.

4. **ability to parse sql code with newlines**. When I set the parameters with new lines, apply_cluster did not match the third group. For example:
```
options = <<~SQL
  ENGINE = MergeTree()
  ORDER BY expr
  [PARTITION BY expr]
SQL

create_tabel :name, options: options ...
```

5. **additional options for creating view**. By default Clickhouse sets the database name as "default" in the "AS" condition unless I specify it explicitly. (same in "TO" condition)

6. In the new versions of Clickhouse database creates with Atomic engine by default. This engine allows you [not to set the engine option](https://clickhouse.com/docs/en/engines/database-engines/atomic/#replicatedmergetree-in-atomic-database). It sets options by default. I would like to use this opportunity by specify _use_default_replicated_merge_tree_params_ in config.